### PR TITLE
fix: proof-page - use read only mount and disable network on docker command

### DIFF
--- a/web/src/pages/proof-page/proof-page.js
+++ b/web/src/pages/proof-page/proof-page.js
@@ -240,7 +240,7 @@ const ProofPage = () => {
                         docker build -t dev-reward-script .
                       </p>
                       <p className={styles.paragraph}>
-                        docker run -it -v ~/.ssh:/root/.ssh dev-reward-script
+                        docker run -it --network none -v ~/.ssh:/root/.ssh:ro dev-reward-script
                       </p>
                     </div>
                     For python:


### PR DESCRIPTION
Updating docs to run the docker command in a safer way. Related to https://github.com/fluencelabs/dev-rewards/pull/14 